### PR TITLE
Splitting out ENV calls to prevent OPENHAB_DIR from being empty when referenced later

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 FROM alpine:latest
 MAINTAINER peez@stiffi.de
 
-ENV OPENHAB_VERSION=1.8.1 \
-    OPENHAB_DIR=/opt/openhab \
-    BINDINGS_DIR=/opt/openhab-all-bindings \
-    DESIGNER_DIR=/opt/openhab-designer \
-    HABMIN_DIR=$OPENHAB_DIR/webapps/habmin
+ENV OPENHAB_VERSION=1.8.1
+ENV OPENHAB_DIR=/opt/openhab
+ENV BINDINGS_DIR=/opt/openhab-all-bindings
+ENV DESIGNER_DIR=/opt/openhab-designer
+ENV HABMIN_DIR=$OPENHAB_DIR/webapps/habmin
 
 RUN apk add --no-cache openjdk8-jre wget unzip
 


### PR DESCRIPTION
This fixes HABmin. Currently it was put under /webapps/habmin instead of $OPENHAB_DIR/webapps/habmin. You cannot reference a ENV variable inside of a combined assignment.
