### PR TITLE
UID is not set in Alpine Linux

### DIFF
--- a/files/start-openhab-docker.sh
+++ b/files/start-openhab-docker.sh
@@ -4,7 +4,7 @@ BINDINGS_CONFIG_FILE=$OPENHAB_DIR/configurations/bindings.list
 BINDINGS_CONFIG_DIR=$OPENHAB_DIR/addons
 
 # set current user as owner of config files
-chown -R $UID $OPENHAB_DIR/configurations
+chown -R `whoami` $OPENHAB_DIR/configurations
 
 if [ -f "$BINDINGS_CONFIG_FILE" ]
 then


### PR DESCRIPTION
Results in:

> BusyBox v1.24.1 (2015-12-16 08:00:02 GMT) multi-call binary.
> 
> Usage: chown [-RhLHPcvf]... OWNER[<.|:>[GROUP]] FILE...
> 
> Change the owner and/or group of each FILE to OWNER and/or GROUP
> 
>   -R  Recurse
>   -h  Affect symlinks instead of symlink targets
>   -L  Traverse all symlinks to directories
>   -H  Traverse symlinks on command line only
>   -P  Don't traverse symlinks (default)
>   -c  List changed files
>   -v  List all files
>   -f  Hide errors
